### PR TITLE
Fixed for degenerated slices.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
 # command to install dependencies
 install:
   - pip install -r requirements.txt
+  - pip install pytest pytest-cache pytest-benchmark
   - pip install .
-  - pip uninstall -y pytest-isort
 # command to run tests
-script: pytest --pep8 -s
+script: pytest -s

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include avl_module.pyx
-include avl.pxc
+include avl.pxd
 include test/*.py
 include avl.c
 include avl.h
+exclude avl_module.c

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,1 @@
 Cython
-pytest
-pytest-cache
-pytest-isort
-pytest-benchmark

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,13 @@
 # -*- Mode: Python; coding: iso-8859-1 -*-
-from __future__ import absolute_import, division, print_function
+from __future__ import division, print_function, absolute_import
 
+# Standard libraries.
 from distutils.core import Extension, setup
 
 # Third party libraries.
 from Cython.Build import cythonize
 
-VERSION = "2.2.1"
+VERSION = "2.2.2"
 
 setup(
     name="avl",

--- a/test/test_doc.py
+++ b/test/test_doc.py
@@ -2,15 +2,15 @@
 # -*- coding: utf-8 -*-
 """test cases from documentation.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import (
+    division, print_function, absolute_import, unicode_literals)
 
+# Standard libraries.
 import sys
 
-import pytest
-
-# DNV GL libraries.
+# Third party libraries.
 import avl
+import pytest
 
 if sys.version_info > (3, ):
     unicode = str
@@ -150,6 +150,18 @@ def test_8():
 # [If you want a list, use the slice_as_list() method]
 def test_9(random_tree):
     assert str(random_tree[3:8]) == "[30, 40, 42, 48, 50]"
+
+
+def test_degenerated_slice_1(random_tree):
+    assert str(random_tree[8:8]) == "[]"
+
+
+def test_degenerated_slice_2(random_tree):
+    assert str(random_tree[200:200]) == "[]"
+
+
+def test_degenerated_slice_3(random_tree):
+    assert str(random_tree[200:100]) == "[]"
 
 
 def test_10(random_tree):

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,5 @@ skip_missing_interpreters = true
 deps =
     -r requirements.txt
     pytest
-    pytest-isort
 commands =
-    pytest --isort
+    pytest


### PR DESCRIPTION
Returns empty tree now for [i:j] when j<=i. Raised an error
"IndexError: invalid slice".

Also fixed some compilation problems with Cython.